### PR TITLE
Fix Null, add status to /pvp

### DIFF
--- a/src/com/github/aasmus/pvptoggle/PvPCommand.java
+++ b/src/com/github/aasmus/pvptoggle/PvPCommand.java
@@ -58,6 +58,7 @@ public class PvPCommand implements CommandExecutor {
 			if(cmd.getName().equalsIgnoreCase("pvp")) {
 				Player p = (Player) sender;
 				if(args.length == 0) {
+					Chat.send(p, "PVP_STATUS", null, PvPToggle.players.get(p.getUniqueId()));
 					Chat.send(p, "HELP_HEADER");
 					Chat.send(p, "HELP_GENERAL_USEAGE");
 					if(p.hasPermission("pvptoggle.others"))
@@ -71,7 +72,7 @@ public class PvPCommand implements CommandExecutor {
 							Boolean current = PvPToggle.players.get(p.getUniqueId());
 							if(args[0].equals("toggle")) {
 								Util.setCooldownTime(p);
-								if(current == true) {
+								if(current == null || current == true) {
 									Util.setPlayerState(p.getUniqueId(), false);
 									Chat.send(p, "PVP_STATE_ENABLED");
 									if(PvPToggle.instance.getConfig().getBoolean("SETTINGS.PARTICLES")) {

--- a/src/com/github/aasmus/pvptoggle/PvPCommand.java
+++ b/src/com/github/aasmus/pvptoggle/PvPCommand.java
@@ -79,7 +79,7 @@ public class PvPCommand implements CommandExecutor {
 							Boolean current = PvPToggle.players.get(p.getUniqueId());
 							if(args[0].equals("toggle")) {
 								Util.setCooldownTime(p);
-								if(current == null || current == true) {
+								if(current == true) {
 									Util.setPlayerState(p.getUniqueId(), false);
 									Chat.send(p, "PVP_STATE_ENABLED");
 									if(PvPToggle.instance.getConfig().getBoolean("SETTINGS.PARTICLES")) {

--- a/src/com/github/aasmus/pvptoggle/PvPToggle.java
+++ b/src/com/github/aasmus/pvptoggle/PvPToggle.java
@@ -44,7 +44,7 @@ public class PvPToggle extends JavaPlugin implements Listener {
 		
 		if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
 			new PlaceholderAPIHook(this).register();
-		}		
+		}
 	}
 
     @Override

--- a/src/com/github/aasmus/pvptoggle/listeners/PlayerJoin.java
+++ b/src/com/github/aasmus/pvptoggle/listeners/PlayerJoin.java
@@ -7,8 +7,18 @@ import org.bukkit.event.player.PlayerJoinEvent;
 
 import com.github.aasmus.pvptoggle.PvPToggle;
 import com.github.aasmus.pvptoggle.utils.Util;
+import org.bukkit.Bukkit;
 
 public class PlayerJoin implements Listener {
+	
+	public PlayerJoin() {
+		for(Player p : Bukkit.getOnlinePlayers()) {
+			PvPToggle.players.put(p.getUniqueId(), PvPToggle.instance.getConfig().getBoolean("SETTINGS.DEFAULT_PVP_OFF")); //add player to players hash map and set their pvp state to off
+			if(PvPToggle.players.get(p.getUniqueId()) == false && PvPToggle.instance.getConfig().getBoolean("SETTINGS.PARTICLES")) {
+				Util.particleEffect(p.getPlayer());
+			}
+		}
+	}
 	
 	@EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {

--- a/src/com/github/aasmus/pvptoggle/utils/Chat.java
+++ b/src/com/github/aasmus/pvptoggle/utils/Chat.java
@@ -32,7 +32,7 @@ public class Chat {
 		if(msg.equals(""))
 			return;
 		String output = msg.replaceAll("<parameter>", parameter);
-		if(pvpState == true) {
+		if(pvpState != null ? pvpState == true : PvPToggle.instance.getConfig().getBoolean("SETTINGS.DEFAULT_PVP_OFF")) {
 			output = output.replaceAll("<pvpstate>", "off");
 		} else {
 			output = output.replaceAll("<pvpstate>", "on");

--- a/src/com/github/aasmus/pvptoggle/utils/Chat.java
+++ b/src/com/github/aasmus/pvptoggle/utils/Chat.java
@@ -32,7 +32,7 @@ public class Chat {
 		if(msg.equals(""))
 			return;
 		String output = msg.replaceAll("<parameter>", parameter);
-		if(pvpState != null ? pvpState == true : PvPToggle.instance.getConfig().getBoolean("SETTINGS.DEFAULT_PVP_OFF")) {
+		if(pvpState == true) {
 			output = output.replaceAll("<pvpstate>", "off");
 		} else {
 			output = output.replaceAll("<pvpstate>", "on");

--- a/src/resources/plugin.yml
+++ b/src/resources/plugin.yml
@@ -2,6 +2,7 @@ main: com.github.aasmus.pvptoggle.PvPToggle
 softdepend: [PlaceholderAPI]
 name: PvPToggle
 version: 1.6.3
+api-version: 1.13
 author: aasmus
 description: Plugin that allows players to toggle PvP state
 commands:


### PR DESCRIPTION
Mostly related to dynamically loading the plugin, also adds more information to the `/pvp` command (ease of use)